### PR TITLE
Introduce Gabby Grove support for feeds and messages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import {BlobId, FeedId, MsgId} from 'ssb-typescript';
 const urlParse = require('url-parse');
 
-type FeedTF = ['feed', 'ed25519'] | ['feed', 'bendybutt-v1'];
-type MessageTF = ['message', 'sha256'] | ['message', 'bendybutt-v1'];
+type FeedTF = ['feed', 'ed25519'] | ['feed', 'bendybutt-v1'] | ['feed', 'gabbygrove-v1'];
+type MessageTF = ['message', 'sha256'] | ['message', 'bendybutt-v1'] | ['message', 'gabbygrove-v1'];
 type BlobTF = ['blob', 'sha256'];
 type AddressTF = ['address', 'multiserver'];
 type EncryptionKeyTF = ['encryption-key', 'box2-dm-dh'];
@@ -93,12 +93,20 @@ export function isBendyButtV1FeedSSBURI(uri: string | null) {
   return checkTypeFormat(uri, 'feed', 'bendybutt-v1');
 }
 
+export function isGabbyGroveV1FeedSSBURI(uri: string | null) {
+  return checkTypeFormat(uri, 'feed', 'gabbygrove-v1');
+}
+
 export function isMessageSSBURI(uri: string | null) {
   return checkTypeFormat(uri, 'message', 'sha256');
 }
 
 export function isBendyButtV1MessageSSBURI(uri: string | null) {
   return checkTypeFormat(uri, 'message', 'bendybutt-v1');
+}
+
+export function isGabbyGroveV1MessageSSBURI(uri: string | null) {
+  return checkTypeFormat(uri, 'message', 'gabbygrove-v1');
 }
 
 export function isBlobSSBURI(uri: string | null) {
@@ -142,8 +150,10 @@ export function isSSBURI(uri: string | null) {
   return (
     isFeedSSBURI(uri) ||
     isBendyButtV1FeedSSBURI(uri) ||
+    isGabbyGroveV1FeedSSBURI(uri) ||
     isMessageSSBURI(uri) ||
     isBendyButtV1MessageSSBURI(uri) ||
+    isGabbyGroveV1MessageSSBURI(uri) ||
     isBlobSSBURI(uri) ||
     isAddressSSBURI(uri) ||
     isEncryptionKeyBox2DMDiffieHellmanSSBURI(uri) ||

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -7,6 +7,7 @@ module.exports.message = {
   uri2: 'ssb:message:sha256:g3hPVPDEO1Aj_uPl0-J2NlhFB2bbFLIHlty-YuqFZ3w=',
   uri3: 'ssb://message/sha256/g3hPVPDEO1Aj_uPl0-J2NlhFB2bbFLIHlty-YuqFZ3w=',
   uri4: 'ssb://message/bendybutt-v1/Z0rMVMDEO1Aj0uPl0_J2NlhFB2bbFLIHlty_YuqArFq=',
+  uri5: 'ssb:message/gabbygrove-v1/QibgMEFVrupoOpiILKVoNXnhzdVQVZf7dkmL9MSXO5g=',
 };
 
 module.exports.feed = {
@@ -15,6 +16,7 @@ module.exports.feed = {
   uri2: 'ssb:feed:ed25519:-oaWWDs8g73EZFUMfW37R_ULtFEjwKN_DczvdYihjbU=',
   uri3: 'ssb://feed/ed25519/-oaWWDs8g73EZFUMfW37R_ULtFEjwKN_DczvdYihjbU=',
   uri4: 'ssb:feed/bendybutt-v1/APaWWDs8g73EZFUMfW37RBULtFEjwKNbDczvdYiRXtA=',
+  uri5: 'ssb:feed/gabbygrove-v1/FY5OG311W4j_KPh8H9B2MZt4WSziy_p-ABkKERJdujQ=',
 };
 
 module.exports.blob = {

--- a/test/happy.js
+++ b/test/happy.js
@@ -5,13 +5,14 @@ const fixtures = require('./fixtures');
 const ssbUri = require('../lib');
 
 test('message URIs recognized', (t) => {
-  t.plan(5);
+  t.plan(6);
   t.true(ssbUri.isSSBURI(fixtures.message.uri));
   t.true(ssbUri.isMessageSSBURI(fixtures.message.uri));
   t.true(ssbUri.isMessageSSBURI(fixtures.message.uri2));
   t.true(ssbUri.isMessageSSBURI(fixtures.message.uri3));
 
   t.true(ssbUri.isBendyButtV1MessageSSBURI(fixtures.message.uri4))
+  t.true(ssbUri.isGabbyGroveV1MessageSSBURI(fixtures.message.uri5))
 });
 
 test('message from sigil to URI', (t) => {
@@ -27,13 +28,14 @@ test('message from URI to sigil', (t) => {
 });
 
 test('feed URIs recognized', (t) => {
-  t.plan(5);
+  t.plan(6);
   t.true(ssbUri.isSSBURI(fixtures.feed.uri));
   t.true(ssbUri.isFeedSSBURI(fixtures.feed.uri));
   t.true(ssbUri.isFeedSSBURI(fixtures.feed.uri2));
   t.true(ssbUri.isFeedSSBURI(fixtures.feed.uri3));
 
   t.true(ssbUri.isBendyButtV1FeedSSBURI(fixtures.feed.uri4));
+  t.true(ssbUri.isGabbyGroveV1FeedSSBURI(fixtures.feed.uri5));
 });
 
 test('feed from sigil to URI', (t) => {

--- a/test/sad.js
+++ b/test/sad.js
@@ -13,6 +13,11 @@ test('bendybutt message URI cannot be converted to sigil', (t) => {
   t.notOk(ssbUri.toMessageSigil(fixtures.message.uri4));
 });
 
+test('gabbygrove message URI cannot be converted to sigil', (t) => {
+  t.plan(1);
+  t.notOk(ssbUri.toMessageSigil(fixtures.message.uri5));
+});
+
 test('falsy input not recognized as feed', (t) => {
   t.plan(1);
   t.false(ssbUri.isFeedSSBURI(null));
@@ -51,6 +56,11 @@ test('invalid feed SSB URI cannot be converted to sigil', (t) => {
 test('bendybutt feed URI cannot be converted to sigil', (t) => {
   t.plan(1);
   t.notOk(ssbUri.toFeedSigil(fixtures.feed.uri4));
+});
+
+test('gabbygrove feed URI cannot be converted to sigil', (t) => {
+  t.plan(1);
+  t.notOk(ssbUri.toFeedSigil(fixtures.feed.uri5));
 });
 
 test('invalid message SSB URI cannot be converted to sigil', (t) => {


### PR DESCRIPTION
Adds support for messages and feeds with the Gabby Grove format.

Relates to this PR for adding canonical examples to the spec: https://github.com/ssb-ngi-pointer/ssb-uri-spec/pull/9

Relevant docs: [Gabby Grove for Go](https://pkg.go.dev/go.mindeco.de/ssb-gabbygrove) & [go-gabbygrove repo](https://git.sr.ht/~cryptix/go-gabbygrove).