### PR TITLE
Support URI to sigil conversion for Bendy Butt and Gabby Grove feeds

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ export function fromMultiserverAddress(msaddr: string) {
 }
 
 export function toFeedSigil(uri: string): FeedId | null {
-  if (!isFeedSSBURI(uri)) return null;
+  if (!isFeedSSBURI(uri) && !isBendyButtV1FeedSSBURI(uri) && !isGabbyGroveV1FeedSSBURI(uri)) return null;
   const base64Data = extractBase64Data(urlParse(uri, true).pathname)!;
   if (!base64Data) return null;
   return `@${base64Data}.ed25519`;

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -15,8 +15,8 @@ module.exports.feed = {
   uri: 'ssb:feed/ed25519/-oaWWDs8g73EZFUMfW37R_ULtFEjwKN_DczvdYihjbU=',
   uri2: 'ssb:feed:ed25519:-oaWWDs8g73EZFUMfW37R_ULtFEjwKN_DczvdYihjbU=',
   uri3: 'ssb://feed/ed25519/-oaWWDs8g73EZFUMfW37R_ULtFEjwKN_DczvdYihjbU=',
-  uri4: 'ssb:feed/bendybutt-v1/APaWWDs8g73EZFUMfW37RBULtFEjwKNbDczvdYiRXtA=',
-  uri5: 'ssb:feed/gabbygrove-v1/FY5OG311W4j_KPh8H9B2MZt4WSziy_p-ABkKERJdujQ=',
+  uri4: 'ssb:feed/bendybutt-v1/-oaWWDs8g73EZFUMfW37R_ULtFEjwKN_DczvdYihjbU=',
+  uri5: 'ssb:feed/gabbygrove-v1/-oaWWDs8g73EZFUMfW37R_ULtFEjwKN_DczvdYihjbU=',
 };
 
 module.exports.blob = {

--- a/test/happy.js
+++ b/test/happy.js
@@ -50,6 +50,18 @@ test('feed from URI to sigil', (t) => {
   t.equal(sigil, fixtures.feed.sigil);
 });
 
+test('bendy butt feed from URI to sigil', (t) => {
+  t.plan(1);
+  const sigil = ssbUri.toFeedSigil(fixtures.feed.uri4);
+  t.equal(sigil, fixtures.feed.sigil);
+});
+
+test('gabby grove feed from URI to sigil', (t) => {
+  t.plan(1);
+  const sigil = ssbUri.toFeedSigil(fixtures.feed.uri5);
+  t.equal(sigil, fixtures.feed.sigil);
+});
+
 test('blob URIs recognized', (t) => {
   t.plan(4);
   t.true(ssbUri.isSSBURI(fixtures.blob.uri));

--- a/test/sad.js
+++ b/test/sad.js
@@ -53,16 +53,6 @@ test('invalid feed SSB URI cannot be converted to sigil', (t) => {
   t.false(ssbUri.toFeedSigil('ssb:'));
 });
 
-test('bendybutt feed URI cannot be converted to sigil', (t) => {
-  t.plan(1);
-  t.notOk(ssbUri.toFeedSigil(fixtures.feed.uri4));
-});
-
-test('gabbygrove feed URI cannot be converted to sigil', (t) => {
-  t.plan(1);
-  t.notOk(ssbUri.toFeedSigil(fixtures.feed.uri5));
-});
-
 test('invalid message SSB URI cannot be converted to sigil', (t) => {
   t.plan(1);
   t.false(ssbUri.toMessageSigil('ssb:'));


### PR DESCRIPTION
This PR extends the `toFeedSigil()` function to accept feed URIs for Bendy Butt and Gabby Grove and convert them to sigil-based representations.

I'm not entirely sure this is a good idea but the changes were quick and we can discuss here.

**Context:**

`ssbKeys.verify()` expects the public key to be in the form of a sigil-based key. I have run into a situation in ssb-meta-feeds validation where the `subfeedKey` signing the `content` is a `gabbygrove-v1` URI. Signature verification fails when this `subfeedKey` is supplied as the public key, but passes if the key is converter to a sigil-based representation.

